### PR TITLE
Tests, implementation and documentation for from_quaternion

### DIFF
--- a/doc/source/spatial.transform.rst
+++ b/doc/source/spatial.transform.rst
@@ -1,0 +1,1 @@
+.. automodule:: scipy.spatial.transform

--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -7,7 +7,7 @@ Spatial algorithms and data structures (:mod:`scipy.spatial`)
 
 Spatial Transformations
 =======================
-Contained in the :mod:`scipy.spatial.transform` submodule.
+Contained in the `scipy.spatial.transform` submodule.
 
 Nearest-neighbor Queries
 ========================

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -14,6 +14,9 @@ def configuration(parent_package='', top_path=None):
 
     config.add_data_dir('tests')
 
+    # spatial.transform
+    config.add_subpackage('transform')
+
     # qhull
     qhull_src = list(glob.glob(join(dirname(__file__), 'qhull',
                                     'src', '*.c')))

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1,12 +1,56 @@
 from __future__ import division, print_function, absolute_import
 
+__all__ = ['Rotation']
+
 import numpy as np
+import scipy.linalg
 
 class Rotation(object):
     """Rotation in 3 dimensions.
 
     This class will include initializers from different representations, converters
     and some useful algorithms such as quaternion slerp and rotation estimation.
+
     """
-    def __init__(self):
-        pass
+    def __init__(self, quaternions):
+        """Initialize class from normalized quaternions.
+
+        Parameters
+        ----------
+        quaternions : (N, 4) numpy.array
+                      Each row is a unit-norm quaternion stored in scalar-last
+                      (x, y, z, w) format.
+
+        """
+        self._quat = quaternions
+
+    @classmethod
+    def from_quaternion(cls, quat):
+        """Initialize Rotation from possibly unnormalized quaternions
+
+        This classmethod normalizes the input quaternions and returns a
+        `Rotation` object.
+
+        Parameters
+        ----------
+        quat : (N, 4) or (4,) numpy.array
+               Each row is a (possibly non-unit norm) quaternion in scalar-last
+               (x, y, z, w) format.
+
+        """
+
+        # If a single quaternion is given, convert it to a 2D 1 x 4 matrix
+        if quat.shape == (4,):
+            quat = quat[None, :]
+
+        # Each row should have 4 numbers
+        assert(quat.shape[1] == 4)
+
+        # L2 norm of each row
+        norms = scipy.linalg.norm(quat, axis=1)
+
+        # Divide each row by its norm.
+        # In case quat is [4 x 4], ensure norm is broadcasted along each column
+        normalised_quat = quat / norms[:, None]
+
+        return cls(normalised_quat)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -16,59 +16,60 @@ class Rotation(object):
     Methods
     -------
     from_quaternion
-
     """
     def __init__(self, quat, normalized=False):
         self._single = False
         # Try to convert to numpy array
-        quat = np.asarray(quat)
+        quat = np.asarray(quat, dtype=float)
+
+        if quat.ndim not in [1, 2]:
+            raise ValueError("Input quat should be of shape (4,) or (N x 4).")
 
         # If a single quaternion is given, convert it to a 2D 1 x 4 matrix but
         # set self._single to True so that we can return appropriate objects
         # in the `to_...` methods
-        if quat.shape == (4,):
+        if quat.ndim == 1:
             quat = quat[None, :]
             self._single = True
 
         # Each row should have 4 numbers
         if quat.shape[1] != 4:
-            raise ValueError("A quaternion should have 4 numbers in (x,y,z,w) format")
+            raise ValueError("A quaternion should have 4 numbers.")
 
-        normalized_quat = quat
+        self._quat = quat
+
         if not normalized:
             # L2 norm of each row
             norms = scipy.linalg.norm(quat, axis=1)
 
-            # Warn user for zero (eps?) norm and set to identity quaternion, which
-            # is (0,0,0,1) in (x,y,z,w) format
-            bool_indices = norms == 0
-            if np.any(bool_indices == True):
-                warnings.warn("Found zero norm quaternions in input, replacing with identity quaternions")
-                quat[bool_indices] = np.array([0, 0, 0, 1])
-                norms[bool_indices] = 1.0
-
-            # Normalize each quaternion
-            # In case quat is [4 x 4], ensure norm is broadcasted along each column
-            normalised_quat = quat / norms[:, None]
-        self._quat = normalised_quat
+            # Warn user for zero (eps?) norm and set to identity quaternion,
+            # which (0,0,0,1) in (x,y,z,w) format
+            zero_norms = norms == 0
+            if zero_norms.any():
+                warnings.warn("Found zero norm quaternions in input, replacing with identity quaternions.")
+                self._quat[zero_norms] = np.array([0, 0, 0, 1])
+            # Normalize each quaternion, ensuring norm is broadcasted along
+            # each column.
+            self._quat[~zero_norms] /= norms[~zero_norms][:, None]
 
     @classmethod
     def from_quaternion(cls, quat, normalized=False):
-        """Initialize Rotation from possibly unnormalized quaternions.
+        """Initialize Rotation from quaternions.
 
-        This classmethod normalizes the input quaternions and returns a
-        `Rotation` object.
+        This classmethod returns a `Rotation` object from the input quaternions.
+        If `normalized` is `True`, then the quaternions are assumed to have
+        unit norm, else the quaternions are normalized before the object is
+        created.
 
         Parameters
         ----------
         quat : array_like, shape (N, 4) or (4,)
-               Each row is a (possibly non-unit norm) quaternion in scalar-last
-               (x, y, z, w) format.
+            Each row is a (possibly non-unit norm) quaternion in scalar-last
+            (x, y, z, w) format.
 
-        normalized : boolean, optional, default = False
-                     If this flag is `True`, then it is assumed that the input
-                     quaternions all have unit norm and are not normalized again.
-
+        normalized : boolean, optional
+            If this flag is `True`, then it is assumed that the input quaternions
+            all have unit norm and are not normalized again. Default is False.
         """
 
         return cls(quat, normalized)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -22,23 +22,20 @@ class Rotation(object):
         # Try to convert to numpy array
         quat = np.asarray(quat, dtype=float)
 
-        if quat.ndim not in [1, 2]:
-            raise ValueError("Input quat should be of shape (4,) or (N x 4).")
+        if quat.ndim not in [1, 2] or quat.shape[-1] != 4:
+            raise ValueError("`quat` should be of shape (4,) or (N x 4).")
 
         # If a single quaternion is given, convert it to a 2D 1 x 4 matrix but
         # set self._single to True so that we can return appropriate objects
         # in the `to_...` methods
-        if quat.ndim == 1:
+        if quat.shape == (4,):
             quat = quat[None, :]
             self._single = True
-
-        # Each row should have 4 numbers
-        if quat.shape[1] != 4:
-            raise ValueError("A quaternion should have 4 numbers.")
 
         self._quat = quat
 
         if not normalized:
+            self._quat = quat.copy()
             # L2 norm of each row
             norms = scipy.linalg.norm(quat, axis=1)
 
@@ -66,7 +63,6 @@ class Rotation(object):
         quat : array_like, shape (N, 4) or (4,)
             Each row is a (possibly non-unit norm) quaternion in scalar-last
             (x, y, z, w) format.
-
         normalized : boolean, optional
             If this flag is `True`, then it is assumed that the input quaternions
             all have unit norm and are not normalized again. Default is False.

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -32,9 +32,9 @@ class Rotation(object):
             quat = quat[None, :]
             self._single = True
 
-        self._quat = quat
-
-        if not normalized:
+        if normalized:
+            self._quat = quat
+        else:
             self._quat = quat.copy()
             # L2 norm of each row
             norms = scipy.linalg.norm(quat, axis=1)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -1,9 +1,8 @@
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['Rotation']
-
 import numpy as np
 import scipy.linalg
+import warnings
 
 class Rotation(object):
     """Rotation in 3 dimensions.
@@ -11,45 +10,65 @@ class Rotation(object):
     This class will include initializers from different representations, converters
     and some useful algorithms such as quaternion slerp and rotation estimation.
 
+    For initializing Rotations usage of `from_...` methods such as `from_quaternion`
+    is recommended instead of using `__init__`.
+
+    Methods
+    -------
+    from_quaternion
+
     """
-    def __init__(self, quaternions):
-        """Initialize class from possible normalized quaternions.
+    def __init__(self, quat, normalized=False):
+        self._single = False
+        # Try to convert to numpy array
+        quat = np.asarray(quat)
 
-        Parameters
-        ----------
-        quaternions : (N, 4) numpy.array
-                      Each row is a quaternion stored in scalar-last
-                      (x, y, z, w) format.
+        # If a single quaternion is given, convert it to a 2D 1 x 4 matrix but
+        # set self._single to True so that we can return appropriate objects
+        # in the `to_...` methods
+        if quat.shape == (4,):
+            quat = quat[None, :]
+            self._single = True
 
-        """
         # Each row should have 4 numbers
-        assert(quaternions.shape[1] == 4)
+        if quat.shape[1] != 4:
+            raise ValueError("A quaternion should have 4 numbers in (x,y,z,w) format")
 
-        # L2 norm of each row
-        norms = scipy.linalg.norm(quaternions, axis=1)
+        normalized_quat = quat
+        if not normalized:
+            # L2 norm of each row
+            norms = scipy.linalg.norm(quat, axis=1)
 
-        # Divide each row by its norm.
-        # In case quat is [4 x 4], ensure norm is broadcasted along each column
-        normalised_quat = quaternions / norms[:, None]
+            # Warn user for zero (eps?) norm and set to identity quaternion, which
+            # is (0,0,0,1) in (x,y,z,w) format
+            bool_indices = norms == 0
+            if np.any(bool_indices == True):
+                warnings.warn("Found zero norm quaternions in input, replacing with identity quaternions")
+                quat[bool_indices] = np.array([0, 0, 0, 1])
+                norms[bool_indices] = 1.0
+
+            # Normalize each quaternion
+            # In case quat is [4 x 4], ensure norm is broadcasted along each column
+            normalised_quat = quat / norms[:, None]
         self._quat = normalised_quat
 
     @classmethod
-    def from_quaternion(cls, quat):
-        """Initialize Rotation from possibly unnormalized quaternions
+    def from_quaternion(cls, quat, normalized=False):
+        """Initialize Rotation from possibly unnormalized quaternions.
 
         This classmethod normalizes the input quaternions and returns a
         `Rotation` object.
 
         Parameters
         ----------
-        quat : (N, 4) or (4,) numpy.array
+        quat : array_like, shape (N, 4) or (4,)
                Each row is a (possibly non-unit norm) quaternion in scalar-last
                (x, y, z, w) format.
 
+        normalized : boolean, optional, default = False
+                     If this flag is `True`, then it is assumed that the input
+                     quaternions all have unit norm and are not normalized again.
+
         """
 
-        # If a single quaternion is given, convert it to a 2D 1 x 4 matrix
-        if quat.shape == (4,):
-            quat = quat[None, :]
-
-        return cls(quat)
+        return cls(quat, normalized)

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -13,16 +13,25 @@ class Rotation(object):
 
     """
     def __init__(self, quaternions):
-        """Initialize class from normalized quaternions.
+        """Initialize class from possible normalized quaternions.
 
         Parameters
         ----------
         quaternions : (N, 4) numpy.array
-                      Each row is a unit-norm quaternion stored in scalar-last
+                      Each row is a quaternion stored in scalar-last
                       (x, y, z, w) format.
 
         """
-        self._quat = quaternions
+        # Each row should have 4 numbers
+        assert(quaternions.shape[1] == 4)
+
+        # L2 norm of each row
+        norms = scipy.linalg.norm(quaternions, axis=1)
+
+        # Divide each row by its norm.
+        # In case quat is [4 x 4], ensure norm is broadcasted along each column
+        normalised_quat = quaternions / norms[:, None]
+        self._quat = normalised_quat
 
     @classmethod
     def from_quaternion(cls, quat):
@@ -43,14 +52,4 @@ class Rotation(object):
         if quat.shape == (4,):
             quat = quat[None, :]
 
-        # Each row should have 4 numbers
-        assert(quat.shape[1] == 4)
-
-        # L2 norm of each row
-        norms = scipy.linalg.norm(quat, axis=1)
-
-        # Divide each row by its norm.
-        # In case quat is [4 x 4], ensure norm is broadcasted along each column
-        normalised_quat = quat / norms[:, None]
-
-        return cls(normalised_quat)
+        return cls(quat)

--- a/scipy/spatial/transform/setup.py
+++ b/scipy/spatial/transform/setup.py
@@ -1,0 +1,10 @@
+from __future__ import division, print_function, absolute_import
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+
+    config = Configuration('transform', parent_package, top_path)
+
+    config.add_data_dir('tests')
+
+    return config

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1,0 +1,30 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+from scipy.spatial.transform import Rotation
+
+
+def test_generic_quat_matrix():
+    x = np.array([[3,4,0,0], [5, 12, 0, 0]])
+    r = Rotation.from_quaternion(x)
+    expected_quat = x / np.array([[5], [13]])
+    assert_array_almost_equal(r._quat, expected_quat)
+
+def test_from_single_quaternion():
+    x = np.array([3,4,0,0])
+    r = Rotation.from_quaternion(x)
+    expected_quat = x[None, :] / 5
+    assert_array_almost_equal(r._quat, expected_quat)
+
+def test_from_square_quat_matrix():
+    # Ensure proper norm array broadcasting
+    x = np.array([
+        [3, 0, 0, 4],
+        [5, 0, 12, 0],
+        [0, 0, 0, 1],
+        [0, 0, 0, -1]
+        ])
+    r = Rotation.from_quaternion(x)
+    expected_quat = x / np.array([[5], [13], [1], [1]])
+    assert_array_almost_equal(r._quat, expected_quat)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1,5 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
+import pytest
+
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from scipy.spatial.transform import Rotation
@@ -11,11 +13,13 @@ def test_generic_quat_matrix():
     expected_quat = x / np.array([[5], [13]])
     assert_array_almost_equal(r._quat, expected_quat)
 
+
 def test_from_single_quaternion():
     x = np.array([3,4,0,0])
     r = Rotation.from_quaternion(x)
     expected_quat = x[None, :] / 5
     assert_array_almost_equal(r._quat, expected_quat)
+
 
 def test_from_square_quat_matrix():
     # Ensure proper norm array broadcasting
@@ -28,3 +32,32 @@ def test_from_square_quat_matrix():
     r = Rotation.from_quaternion(x)
     expected_quat = x / np.array([[5], [13], [1], [1]])
     assert_array_almost_equal(r._quat, expected_quat)
+
+
+def test_malformed_1d_from_quaternion():
+    with pytest.raises(ValueError):
+        Rotation.from_quaternion(np.array([1,2,3]))
+
+
+def test_malformed_2d_from_quaternion():
+    with pytest.raises(ValueError):
+        Rotation.from_quaternion(np.array([
+            [1,2,3,4,5],
+            [4,5,6,7,8]
+            ]))
+
+
+def test_zero_norms_from_quaternion():
+    x = np.array([
+            [3, 4, 0, 0],
+            [0, 0, 0, 0],
+            [5, 0, 12, 0]
+            ])
+    with pytest.raises(UserWarning):
+        r = Rotation.from_quaternion(x)
+        expected_quat = np.array([
+            x[0] / 5,
+            [0, 0, 0, 1],
+            x[2] / 13
+            ])
+        assert_array_almost_equal(r, expected_quat)


### PR DESCRIPTION
The `__init__` function accepts prepared quaternion matrices of size `[N x 4]`. The `from_quaternion` function accepts `numpy.array` of shape `(4, )` or `(N x 4)`, prepares them and calls `__init__`.

Tests have been run with `scipy.spatial.transform.test()`