### PR TITLE
Implementation and tests for conversion to direction cosine matrices

### DIFF
--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -89,7 +89,7 @@ class Rotation(object):
     def as_dcm(self):
         """Return the direction cosine matrix representation of the Rotation.
 
-        This function returns a numpy.ndarray of shape (3 x 3) or (N x 3 x 3)
+        This function returns a numpy.ndarray of shape (3, 3) or (N, 3, 3)
         depending on the input that was used to initialize the object.
         """
 

--- a/scipy/spatial/transform/rotation.py
+++ b/scipy/spatial/transform/rotation.py
@@ -92,17 +92,16 @@ class Rotation(object):
         This function returns a numpy.ndarray of shape (3 x 3) or (N x 3 x 3)
         depending on the input that was used to initialize the object.
         """
-        quat = self._quat.copy()
 
-        x = quat[:, 0].reshape(-1, 1)
-        y = quat[:, 1].reshape(-1, 1)
-        z = quat[:, 2].reshape(-1, 1)
-        w = quat[:, 3].reshape(-1, 1)
+        x = self._quat[:, 0]
+        y = self._quat[:, 1]
+        z = self._quat[:, 2]
+        w = self._quat[:, 3]
 
-        x2 = np.power(x, 2)
-        y2 = np.power(y, 2)
-        z2 = np.power(z, 2)
-        w2 = np.power(w, 2)
+        x2 = x * x
+        y2 = y * y
+        z2 = z * z
+        w2 = w * w
 
         xy = x * y
         zw = z * w
@@ -111,13 +110,20 @@ class Rotation(object):
         yz = y * z
         xw = x * w
 
-        d1 = np.concatenate(
-                (x2 - y2 - z2 + w2, 2 * (xy + zw), 2 * (xz - yw)), axis=1)
-        d2 = np.concatenate(
-                (2 * (xy - zw), - x2 + y2 - z2 + w2, 2 * (yz + xw)), axis=1)
-        d3 = np.concatenate(
-                (2 * (xz + yw), 2 * (yz - xw), - x2 - y2 + z2 + w2), axis=1)
-        dcm = np.dstack((d1, d2, d3))
+        num_rotations = self._quat.shape[0]
+        dcm = np.empty((num_rotations, 3, 3))
+
+        dcm[:, 0, 0] = x2 - y2 - z2 + w2
+        dcm[:, 1, 0] = 2 * (xy + zw)
+        dcm[:, 2, 0] = 2 * (xz - yw)
+
+        dcm[:, 0, 1] = 2 * (xy - zw)
+        dcm[:, 1, 1] = - x2 + y2 - z2 + w2
+        dcm[:, 2, 1] = 2 * (yz + xw)
+
+        dcm[:, 0, 2] = 2 * (xz + yw)
+        dcm[:, 1, 2] = 2 * (yz - xw)
+        dcm[:, 2, 2] = - x2 - y2 + z2 + w2
 
         if self._single:
             return dcm[0]

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_equal, assert_array_almost_equal
 from scipy.spatial.transform import Rotation
 
 
@@ -74,7 +74,7 @@ def test_as_dcm_single_1d_quaternion():
 def test_as_dcm_single_2d_quaternion():
     quat = [[0, 0, 1, 1]]
     mat = Rotation.from_quaternion(quat).as_dcm()
-    assert(mat.shape == (1, 3, 3))
+    assert_equal(mat.shape, (1, 3, 3))
     expected_mat = np.array([
         [0, -1, 0],
         [1, 0, 0],
@@ -91,7 +91,7 @@ def test_as_dcm_from_square_input():
             [0, 0, 0, -1]
             ]
     mat = Rotation.from_quaternion(quats).as_dcm()
-    assert(mat.shape == (4, 3, 3))
+    assert_equal(mat.shape, (4, 3, 3))
 
     expected0 = np.array([
         [0, -1, 0],
@@ -118,7 +118,7 @@ def test_as_dcm_from_generic_input():
             [1, 2, 3, 4]
             ]
     mat = Rotation.from_quaternion(quats).as_dcm()
-    assert(mat.shape == (3, 3, 3))
+    assert_equal(mat.shape, (3, 3, 3))
 
     expected0 = np.array([
         [0, -1, 0],

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -62,3 +62,81 @@ def test_zero_norms_from_quaternion():
             ])
     with pytest.raises(ValueError):
         r = Rotation.from_quaternion(x)
+
+
+def test_as_dcm_single_1d_quaternion():
+    quat = [0, 0, 0, 1]
+    mat = Rotation.from_quaternion(quat).as_dcm()
+    # mat.shape == (3,3) due to 1d input
+    assert_array_almost_equal(mat, np.eye(3))
+
+
+def test_as_dcm_single_2d_quaternion():
+    quat = [[0, 0, 1, 1]]
+    mat = Rotation.from_quaternion(quat).as_dcm()
+    assert(mat.shape == (1, 3, 3))
+    expected_mat = np.array([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+        ])
+    assert_array_almost_equal(mat[0], expected_mat)
+
+
+def test_as_dcm_from_square_input():
+    quats = [
+            [0, 0, 1, 1],
+            [0, 1, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, -1]
+            ]
+    mat = Rotation.from_quaternion(quats).as_dcm()
+    assert(mat.shape == (4, 3, 3))
+
+    expected0 = np.array([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+        ])
+    assert_array_almost_equal(mat[0], expected0)
+
+    expected1 = np.array([
+        [0, 0, 1],
+        [0, 1, 0],
+        [-1, 0, 0]
+        ])
+    assert_array_almost_equal(mat[1], expected1)
+
+    assert_array_almost_equal(mat[2], np.eye(3))
+    assert_array_almost_equal(mat[3], np.eye(3))
+
+
+def test_as_dcm_from_generic_input():
+    quats = [
+            [0, 0, 1, 1],
+            [0, 1, 0, 1],
+            [1, 2, 3, 4]
+            ]
+    mat = Rotation.from_quaternion(quats).as_dcm()
+    assert(mat.shape == (3, 3, 3))
+
+    expected0 = np.array([
+        [0, -1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+        ])
+    assert_array_almost_equal(mat[0], expected0)
+
+    expected1 = np.array([
+        [0, 0, 1],
+        [0, 1, 0],
+        [-1, 0, 0]
+        ])
+    assert_array_almost_equal(mat[1], expected1)
+
+    expected2 = np.array([
+        [0.4, -2, 2.2],
+        [2.8, 1, 0.4],
+        [-1, 2, 2]
+        ]) / 3
+    assert_array_almost_equal(mat[2], expected2)


### PR DESCRIPTION
It took a while for me to get the shape and axes for concatenation right. Now, `rotation.as_dcm[i]` represents the matrix form of the `ith` index quaternion in the input. Test  cases also check for single quaternion vs a stack containing a single quaternion.